### PR TITLE
Fix AttributeError: jax.tree_map was removed in JAX v0.6.0

### DIFF
--- a/feax/topopt_toolkit/mdmm.py
+++ b/feax/topopt_toolkit/mdmm.py
@@ -25,7 +25,7 @@ def prepare_update(tree):
         A pytree containing the gradient descent ascent update.
     """
     pred = lambda x: isinstance(x, LagrangeMultiplier)
-    return jax.tree_map(lambda x: LagrangeMultiplier(-x.value) if pred(x) else x, tree, is_leaf=pred)
+    return jax.tree.map(lambda x: LagrangeMultiplier(-x.value) if pred(x) else x, tree, is_leaf=pred)
 
 
 def optax_prepare_update():


### PR DESCRIPTION
The jax.tree_map was removed in JAX v0.6.0. This is a simple fix to instead rely on the new jax.tree.map api (jax v0.4.25 or newer). 
This fixes the AttributeError stemming from mdmm.py

> AttributeError: jax.tree_map was removed in JAX v0.6.0: use jax.tree.map (jax v0.4.25 or newer) or jax.tree_util.tree_map (any JAX version).

More info can be found over at their change-log site: https://docs.jax.dev/en/latest/changelog.html#jax-0-6-0-april-16-2025



