### PR TITLE
pre-warm all direct solvers; update batched TO example

### DIFF
--- a/docs/docs/advanced/batched_topology_optimization.md
+++ b/docs/docs/advanced/batched_topology_optimization.md
@@ -1,6 +1,6 @@
 # Batched Topology Optimization with Surface Loads
 
-This tutorial demonstrates how to optimize **multiple load cases in parallel** on a single mesh using `jax.vmap`. Each case has its own SIREN neural density field and a different surface traction, while the FE solve, compliance evaluation, and gradient-based update are all batched.
+This tutorial demonstrates how to optimize **multiple load cases in parallel** on a single mesh using `jax.vmap`. Each case has its own SIREN neural density field and its own spatially varying surface traction on the same boundary, while the FE solve, compliance evaluation, and gradient-based update are all batched.
 
 ## Overview
 
@@ -44,25 +44,26 @@ TRACTION_MAG = 1e2  # Applied traction magnitude
 
 ### Load Patch Locations
 
-Ten patches are distributed evenly along the right edge. Each patch is defined by a `location_fn` that tests whether a point lies within the patch band:
+The mesh uses a single Neumann boundary on the full right edge. The 10 load cases are defined by 10 spatial traction profiles on that same boundary, each centered at a different height:
 
 ```python
 NUM_CASES = 10
 PATCH_HALF_BAND = 0.5 * LY / NUM_CASES + Y_TOL
 PATCH_CENTERS = [LY * (i + 0.5) / NUM_CASES for i in range(NUM_CASES)]
+RIGHT_EDGE = lambda pt: jnp.isclose(pt[0], LX, atol=X_TOL)
 
-def _make_right_patch(center):
-    def loc_fn(pt):
-        return jnp.isclose(pt[0], LX, atol=X_TOL) & (
-            jnp.abs(pt[1] - center) <= PATCH_HALF_BAND
-        )
-    return loc_fn
+def make_right_edge_load_fn(center: float):
+    def load_fn(pt):
+        on_patch = jnp.abs(pt[1] - center) <= PATCH_HALF_BAND
+        return jnp.where(on_patch, TRACTION_MAG, 0.0)
 
-LOAD_LOCATIONS = tuple(_make_right_patch(c) for c in PATCH_CENTERS)
+    return load_fn
 ```
 
-!!! warning "location_fn must be single-argument"
-    FEAX inspects `co_argcount` to distinguish 1-argument (`point`) from 2-argument (`point, node_index`) location functions. Using `lambda pt, _c=center: ...` yields `co_argcount=2`, causing FEAX to misinterpret the default parameter as a node index. Always use a closure instead.
+:::warning
+`location_fn` must be single-argument
+FEAX inspects `co_argcount` to distinguish 1-argument (`point`) from 2-argument (`point, node_index`) location functions. Using `lambda pt, _c=center: ...` yields `co_argcount=2`, causing FEAX to misinterpret the default parameter as a node index. Always use a closure instead.
+:::
 
 ### Linear Elasticity with SIMP
 
@@ -86,10 +87,10 @@ class LinearElasticityProblem(fe.Problem):
         def surface_map(u, x, load):
             traction = jnp.zeros(self.dim)
             return traction.at[-1].set(load)
-        return [surface_map for _ in range(max(1, len(self.location_fns)))]
+        return [surface_map]
 ```
 
-All 10 surface maps share the same physics — the per-case loading is controlled entirely by which surface variables are nonzero.
+The problem has one Neumann boundary, so it exposes one surface map. The 10 load cases differ through the spatial values stored in their surface variables.
 
 ## Density Parameterization with SIREN
 
@@ -126,40 +127,39 @@ After stacking, each leaf array has an extra leading batch dimension of size `NU
 
 ## Batched Surface Variables
 
-The central data-engineering step is assembling `batched_surface_vars` — a PyTree where each leaf has shape `(NUM_CASES, ...)`. For case $k$, only the $k$-th surface patch carries the traction; all other patches are zeroed out:
+The central data-engineering step is assembling `batched_surface_vars` from 10 spatially varying traction fields. Each case contributes one surface variable on the right-edge boundary:
 
 ```python
-tractions = [
-    fe.InternalVars.create_uniform_surface_var(problem, TRACTION_MAG, surface_index=i)
-    for i in range(NUM_CASES)
-]
-
-per_case_surface_vars = []
-for case_idx in range(NUM_CASES):
-    sv = tuple(
-        (tractions[i],) if i == case_idx else (jnp.zeros_like(tractions[i]),)
-        for i in range(NUM_CASES)
+case_surface_vars = [
+    (
+        (
+            fe.InternalVars.create_spatially_varying_surface_var(
+                problem,
+                make_right_edge_load_fn(center),
+                surface_index=0,
+            ),
+        ),
     )
-    per_case_surface_vars.append(sv)
+    for center in PATCH_CENTERS
+]
 
 batched_surface_vars = jax.tree_util.tree_map(
     lambda *xs: jnp.stack(xs, axis=0),
-    *per_case_surface_vars,
+    *case_surface_vars,
 )
 ```
 
-This produces a structure where `batched_surface_vars[case_idx]` activates only the traction at patch `case_idx`.
+This produces a PyTree where each leaf has a leading batch dimension of size `NUM_CASES`, and `batched_surface_vars[case_idx]` contains the traction field for load case `case_idx`.
 
-## cuDSS Pre-warming
+## Solver Pre-warming
 
-When using the `cudss` direct solver, the solver must be initialized with a concrete sparse matrix **before** any `jax.vmap` tracing occurs. Pass a sample `internal_vars` to `create_solver`:
+The example passes a concrete `internal_vars` sample to `create_solver` before any `jax.vmap` tracing occurs. This lets FEAX initialize the direct solver and establish the sparse structure once up front:
 
 ```python
 sample_rho = jnp.full(problem.num_cells, TARGET_VOLUME_FRACTION)
-sample_surface_vars = tuple((t,) for t in tractions)
 sample_internal_vars = fe.InternalVars(
     volume_vars=(sample_rho,),
-    surface_vars=sample_surface_vars,
+    surface_vars=case_surface_vars[0],
 )
 
 solver = fe.create_solver(
@@ -171,8 +171,10 @@ solver = fe.create_solver(
 )
 ```
 
-!!! warning "ConcretizationTypeError without pre-warming"
-    If `internal_vars` is omitted, cuDSS initialization is deferred to the first solve call. When that first call happens inside `jax.vmap`, JAX tracer values are passed where concrete values are required, resulting in a `ConcretizationTypeError`. Always provide `internal_vars` when combining cuDSS with `vmap`.
+:::warning
+ConcretizationTypeError without pre-warming
+If `internal_vars` is omitted, direct solver initialization is deferred to the first solve call. When that first call happens inside `jax.vmap`, JAX tracer values are passed where concrete values are required, resulting in a `ConcretizationTypeError`. Always provide `internal_vars` when combining direct solvers with `vmap`.
+:::
 
 ## Batched Loss and Optimization
 
@@ -253,13 +255,13 @@ for case_index, case_name in enumerate(CASE_NAMES):
 
 | Concept | How it is used |
 |---|---|
-| `location_fns` | Define multiple surface load regions on one `Problem` |
-| `InternalVars.surface_vars` | Per-surface-patch traction arrays, zeroed selectively per case |
+| `location_fns` | Define the single right-edge Neumann boundary on the `Problem` |
+| `InternalVars.surface_vars` | Store one spatially varying traction field per load case |
 | `jax.tree_util.tree_map` + `jnp.stack` | Stack per-case PyTrees into batched arrays |
 | `jax.vmap(solve_forward)` | Vectorize the FE solve + compliance over all load cases |
 | `eqx.filter_jit` / `eqx.filter_value_and_grad` | JIT-compile and differentiate through Equinox models |
 | `jax.vmap(optimizer.update)` | Independent optimizer state per case |
-| cuDSS pre-warming | Pass `internal_vars` to `create_solver` to avoid tracer errors under `vmap` |
+| Solver pre-warming | Pass `internal_vars` to `create_solver` so direct-solver setup happens before the batched loop |
 
 ## Complete Code
 

--- a/examples/advance/topology_optimization_batched_surface_loads.py
+++ b/examples/advance/topology_optimization_batched_surface_loads.py
@@ -70,22 +70,25 @@ Y_TOL = 1e-5 * max(1.0, LY)
 PATCH_HALF_BAND = 0.5 * LY / NUM_CASES + Y_TOL
 
 CASE_NAMES = tuple(f"cantilever_{i}" for i in range(NUM_CASES))
-LEFT = lambda pt: jnp.isclose(pt[0], 0.0, atol=X_TOL)
+LEFT_EDGE = lambda pt: jnp.isclose(pt[0], 0.0, atol=X_TOL)
+RIGHT_EDGE = lambda pt: jnp.isclose(pt[0], LX, atol=X_TOL)
 
 # 10 load patches evenly spaced along the right edge
 PATCH_CENTERS = [LY * (i + 0.5) / NUM_CASES for i in range(NUM_CASES)]
 
-def _make_right_patch(center):
-    def loc_fn(pt):
-        return jnp.isclose(pt[0], LX, atol=X_TOL) & (jnp.abs(pt[1] - center) <= PATCH_HALF_BAND)
-    return loc_fn
 
-LOAD_LOCATIONS = tuple(_make_right_patch(c) for c in PATCH_CENTERS)
+def make_right_edge_load_fn(center: float):
+    def load_fn(pt):
+        on_patch = jnp.abs(pt[1] - center) <= PATCH_HALF_BAND
+        return jnp.where(on_patch, TRACTION_MAG, 0.0)
+
+    return load_fn
 
 
 # -----------------------------------------------------------------------------
 # SIREN model https://www.vincentsitzmann.com/siren/
 # -----------------------------------------------------------------------------
+
 
 def siren_weight_init(key, shape, omega: float, *, first_layer: bool):
     fan_in = shape[-2]
@@ -148,6 +151,7 @@ class SIREN(eqx.Module):
             x = jnp.sin(self.omega * (x @ weight + bias))
         return x @ self.weights[-1] + self.biases[-1]
 
+
 def predict_densities(models, coords):
     logits = jax.vmap(lambda model: model(coords))(models)
     return jax.nn.sigmoid(jnp.squeeze(logits, axis=-1))
@@ -156,6 +160,7 @@ def predict_densities(models, coords):
 # -----------------------------------------------------------------------------
 # FE problem setup
 # -----------------------------------------------------------------------------
+
 
 class LinearElasticityProblem(fe.Problem):
     def custom_init(self, E0: float, E_eps: float, nu: float, p: float):
@@ -179,12 +184,13 @@ class LinearElasticityProblem(fe.Problem):
             traction = jnp.zeros(self.dim)
             return traction.at[-1].set(load)
 
-        return [surface_map for _ in range(max(1, len(self.location_fns)))]
+        return [surface_map]
 
 
 # -----------------------------------------------------------------------------
 # Optimization
 # -----------------------------------------------------------------------------
+
 
 def create_model_batch():
     keys = jax.random.split(jax.random.PRNGKey(MODEL_RNG_SEED), len(CASE_NAMES))
@@ -222,6 +228,7 @@ def print_iteration(iteration, total_loss, aux):
 # Main
 # -----------------------------------------------------------------------------
 
+
 def main():
     mesh = fe.mesh.rectangle_mesh(
         Nx=NX,
@@ -236,12 +243,12 @@ def main():
         vec=2,
         dim=2,
         ele_type="QUAD4",
-        location_fns=LOAD_LOCATIONS,
+        location_fns=(RIGHT_EDGE,),
         additional_info=(E0, E_EPS, NU, SIMP_PENALTY),
     )
 
     bc = fe.DirichletBCConfig(
-        [fe.DirichletBCSpec(location=LEFT, component="all", value=0.0)]
+        [fe.DirichletBCSpec(location=LEFT_EDGE, component="all", value=0.0)]
     ).create_bc(problem)
 
     solver_options = fe.DirectSolverOptions(
@@ -252,20 +259,25 @@ def main():
     compliance_fn = gene.create_dynamic_compliance_fn(problem)
     volume_fraction_fn = gene.create_volume_fn(problem)
 
-    # Create traction variable for each load patch
-    tractions = [
-        fe.InternalVars.create_uniform_surface_var(
-            problem, TRACTION_MAG, surface_index=i,
+    # Create spatially varying traction variables for each patch center
+    case_surface_vars = [
+        (
+            (
+                fe.InternalVars.create_spatially_varying_surface_var(
+                    problem,
+                    make_right_edge_load_fn(center),
+                    surface_index=0,
+                ),
+            ),
         )
-        for i in range(NUM_CASES)
+        for center in PATCH_CENTERS
     ]
 
-    # Create sample internal_vars for cuDSS pre-warming (must happen before vmap)
+    # Create sample internal_vars for direct solver pre-warming (must happen before vmap)
     sample_rho = jnp.full(problem.num_cells, TARGET_VOLUME_FRACTION)
-    sample_surface_vars = tuple((t,) for t in tractions)
     sample_internal_vars = fe.InternalVars(
         volume_vars=(sample_rho,),
-        surface_vars=sample_surface_vars,
+        surface_vars=case_surface_vars[0],
     )
     solver = fe.create_solver(
         problem,
@@ -276,19 +288,10 @@ def main():
         internal_vars=sample_internal_vars,
     )
 
-    # For each case, activate only its own load patch (zero out others)
-    per_case_surface_vars = []
-    for case_idx in range(NUM_CASES):
-        sv = tuple(
-            (tractions[i],) if i == case_idx else (jnp.zeros_like(tractions[i]),)
-            for i in range(NUM_CASES)
-        )
-        per_case_surface_vars.append(sv)
     batched_surface_vars = jax.tree_util.tree_map(
         lambda *xs: jnp.stack(xs, axis=0),
-        *per_case_surface_vars,
+        *case_surface_vars,
     )
-
 
     # Normalize centroids to [-1, 1] before feeding them to the SIREN.
     # The SIREN paper analyzes the initialization for inputs in this range and
@@ -308,7 +311,9 @@ def main():
 
     @eqx.filter_jit
     @eqx.filter_value_and_grad(has_aux=True)
-    def batched_loss(models, coords, target_volume_fractions, lams, penalties, batched_surface_vars):
+    def batched_loss(
+        models, coords, target_volume_fractions, lams, penalties, batched_surface_vars
+    ):
         densities = predict_densities(models, coords)
         compliances = jax.vmap(solve_forward)(densities, batched_surface_vars)
         volume_fractions = jax.vmap(volume_fraction_fn)(densities)
@@ -331,9 +336,7 @@ def main():
         optax.clip_by_global_norm(GRAD_CLIP_NORM),
         optax.adabelief(LEARNING_RATE),
     )
-    opt_states = jax.vmap(lambda model: optimizer.init(eqx.filter(model, eqx.is_array)))(
-        models
-    )
+    opt_states = jax.vmap(lambda model: optimizer.init(eqx.filter(model, eqx.is_array)))(models)
 
     target_volume_fractions = jnp.full((len(CASE_NAMES),), TARGET_VOLUME_FRACTION)
     penalties = jnp.full((len(CASE_NAMES),), CONSTRAINT_PENALTY)

--- a/feax/solvers/common.py
+++ b/feax/solvers/common.py
@@ -367,7 +367,7 @@ def create_linear_solve_fn(
     )
 
 
-def prewarm_cudss_solvers(
+def prewarm_direct_solvers(
     problem,
     bc,
     internal_vars,
@@ -377,19 +377,19 @@ def prewarm_cudss_solvers(
     forward_solve_fn,
     adjoint_solve_fn,
 ):
-    """Pre-warm cuDSS solve closures with concrete CSR structure.
+    """Pre-warm direct solve closures with concrete CSR structure.
 
-    This must run outside JAX tracing so the first-call cuDSS initialization
+    This must run outside JAX tracing so the first-call direct initialization
     does not capture tracers in closure state.
     """
 
-    def _is_cudss(opts):
-        return isinstance(opts, DirectSolverOptions) and opts.solver == "cudss"
+    def _is_direct_solver(opts):
+        return isinstance(opts, DirectSolverOptions)
 
     if internal_vars is None:
         return
 
-    if not (_is_cudss(forward_options) or _is_cudss(adjoint_options)):
+    if not (_is_direct_solver(forward_options) or _is_direct_solver(adjoint_options)):
         return
 
     from ..utils import zero_like_initial_guess
@@ -398,14 +398,14 @@ def prewarm_cudss_solvers(
     sample_J = J_bc_func(initial_tmp, internal_vars)
     b_tmp = np.zeros(sample_J.shape[0])
 
-    if _is_cudss(forward_options):
-        print("[feax] Pre-warming cuDSS solver (forward) with sample Jacobian...")
+    if _is_direct_solver(forward_options):
+        print("[feax] Pre-warming direct solver (forward) with sample Jacobian...")
         forward_solve_fn(sample_J, b_tmp, b_tmp)
-        print("[feax] cuDSS solver (forward) initialized.")
-    if _is_cudss(adjoint_options) and adjoint_solve_fn is not forward_solve_fn:
-        print("[feax] Pre-warming cuDSS solver (adjoint) with sample Jacobian...")
+        print("[feax] direct solver (forward) initialized.")
+    if _is_direct_solver(adjoint_options) and adjoint_solve_fn is not forward_solve_fn:
+        print("[feax] Pre-warming direct solver (adjoint) with sample Jacobian...")
         adjoint_solve_fn(sample_J, b_tmp, b_tmp)
-        print("[feax] cuDSS solver (adjoint) initialized.")
+        print("[feax] direct solver (adjoint) initialized.")
 
 
 def _extract_sparse_diagonal(A):

--- a/feax/solvers/linear.py
+++ b/feax/solvers/linear.py
@@ -31,7 +31,7 @@ from .common import (
     _safe_negate,
     check_convergence,
     create_linear_solve_fn,
-    prewarm_cudss_solvers,
+    prewarm_direct_solvers,
     create_x0,
 )
 from .options import (
@@ -291,7 +291,7 @@ def create_linear_solver(
         )
     x0_fn = solver_options.x0_fn if isinstance(solver_options, IterativeSolverOptions) else None
 
-    prewarm_cudss_solvers(
+    prewarm_direct_solvers(
         problem=problem,
         bc=bc,
         internal_vars=internal_vars,

--- a/feax/solvers/newton.py
+++ b/feax/solvers/newton.py
@@ -17,7 +17,7 @@ from .common import (
     check_convergence,
     create_jacobi_preconditioner,
     create_linear_solve_fn,
-    prewarm_cudss_solvers,
+    prewarm_direct_solvers,
     create_x0,
 )
 from .linear import linear_solve_adjoint
@@ -533,8 +533,8 @@ def create_newton_solver(
             # concrete (non-traced) matrix indices. Without this, the first
             # call to jax.jit(linear_solve_fn) would trace through _warmup()
             # and hit TracerArrayConversionError on onp.asarray(A.indices).
-            from .common import prewarm_cudss_solvers
-            prewarm_cudss_solvers(
+            from .common import prewarm_direct_solvers
+            prewarm_direct_solvers(
                 problem=problem,
                 bc=bc,
                 internal_vars=internal_vars,
@@ -612,7 +612,7 @@ def create_newton_solver(
             "make_jittable=False (default) to use the Python-loop path."
         )
 
-    prewarm_cudss_solvers(
+    prewarm_direct_solvers(
         problem=problem,
         bc=bc,
         internal_vars=internal_vars,


### PR DESCRIPTION
Hey @Naruki-Ichihara!

I took a look at your recent changes. Since the addition of the new BCOO-to-CSR conversion, all direct solvers now need to be pre-warmed. Because of that, I changed the API from `prewarm_cudss_solvers` to `prewarm_direct_solvers`.

Additionally, I found a different way to batch Neumann boundary conditions: `fe.InternalVars.create_spatially_varying_surface_var` fits this purpose perfectly. I would argue that both approaches are valid for batching different Neumann conditions, using either one or multiple `location_fns`. However, for this use case, I found that the approach based on `fe.InternalVars.create_spatially_varying_surface_var` uses slightly less CPU time and memory.

Best,
Dominik